### PR TITLE
Ignore Edia-logfiles in the repo root (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/[Ee]dia-logfiles/
 /Assets/Samples
 
 # MemoryCaptures can get excessive in size.


### PR DESCRIPTION
Part of edia-toolbox/edia_core#21.

EDIA writes its logfiles to `/Edia-logfiles` in the project root, so running an experiment from inside this repo leaves them sitting in `git status`, ready to be committed by accident. `edia_core` already ignores that folder; this adds the same line here, in the same place in the file.

One line, no other changes.
